### PR TITLE
feat: add ability to pass env + atlas hcl instead of dev-url

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -35,7 +35,7 @@ function main() {
 
     # Use atlas env if it is set, otherwise use dev-url
     if [[ "$atlas_env" != "" ]]; then
-        atlas_flags=(--env "${atlas_env} --config ${atlas_config}")
+        atlas_flags=(--env "${atlas_env}" --config "${atlas_config}")
     elif [[ "$dev_url" != "" ]]; then
         atlas_flags=(--dev-url "${dev_url}")
     else
@@ -44,7 +44,7 @@ function main() {
     fi
 
     if [[ "$dir" != "" ]]; then
-        atlas_flags+=( --dir ${dir})
+        atlas_flags+=( --dir "${dir}")
 
     fi
 
@@ -56,13 +56,13 @@ function main() {
         # Run the lint command with the web client, and output to json
 
 
-        atlas migrate lint ${atlas_flags[@]} -w --format "{{ json .  }}" --context "${atlas_context}" > "$lint_result_file" 2>&1
+        atlas migrate lint "${atlas_flags[@]}" -w --format "{{ json .  }}" --context "${atlas_context}" > "$lint_result_file" 2>&1
 
         lintResult=$?
 
         if [[ $lintResult -ne 0 ]]; then
             echo -e  ":scream_cat: error running atlas lint\n" | buildkite-agent annotate --context "atlas" --style "error"  --append
-            cat "$lint_result_file" | buildkite-agent annotate --context "atlas" --style "error"  --append
+            buildkite-agent annotate --context "atlas" --style "error" --append < "$lint_result_file"
 
             cat "$lint_result_file"
             exit $lintResult
@@ -103,7 +103,7 @@ function main() {
         fi
 
         # Run validate and exit early, if failed
-        atlas migrate validate ${atlas_flags[@]}
+        atlas migrate validate "${atlas_flags[@]}"
         result=$?
         if [[ $result -ne 0 ]]; then
             exit "$result"
@@ -116,7 +116,7 @@ function main() {
         echo +++ :rocket: push migrations
         # only push on the default branch
         if [ "${BUILDKITE_BRANCH}" = "${default_branch}" ]; then
-            atlas migrate push "${project}" ${atlas_flags[@]} --context "${atlas_context}"
+            atlas migrate push "${project}" "${atlas_flags[@]}" --context "${atlas_context}"
             result=$?
         else
             echo not pushing migration, not running against "${default_branch}" branch

--- a/hooks/command
+++ b/hooks/command
@@ -4,9 +4,10 @@ set -o nounset # script exits when tries to use undeclared variables == set -u
 set -o pipefail # causes pipelines to retain / set the last non-zero status
 
 default_branch=${BUILDKITE_PLUGIN_ATLAS_DEFAULT_BRANCH:-${BUILDKITE_PIPELINE_DEFAULT_BRANCH}}
-dev_url=${BUILDKITE_PLUGIN_ATLAS_DEV_URL}
+dev_url=${BUILDKITE_PLUGIN_ATLAS_DEV_URL:-""}
 project=${BUILDKITE_PLUGIN_ATLAS_PROJECT}
-apply_env=${BUILDKITE_PLUGIN_APPLY_ENV:-"turso"}
+apply_env=${BUILDKITE_PLUGIN_ATLAS_APPLY_ENV:-""}
+atlas_env=${BUILDKITE_PLUGIN_ATLAS_ATLAS_ENV:-""}
 atlas_config=${BUILDKITE_PLUGIN_ATLAS_CONFIG:-"file://atlas.hcl"}
 dir=${BUILDKITE_PLUGIN_ATLAS_DIR}
 step=${BUILDKITE_PLUGIN_ATLAS_STEP:-lint}
@@ -30,13 +31,42 @@ function main() {
     local url=
     local lint_result_file=
 
+    atlas_flags=()
+
+    # Use atlas env if it is set, otherwise use dev-url
+    if [[ "$atlas_env" != "" ]]; then
+        atlas_flags=(--env "${atlas_env} --config ${atlas_config}")
+    elif [[ "$dev_url" != "" ]]; then
+        atlas_flags=(--dev-url "${dev_url}")
+    else
+        echo "No atlas env or dev-url set, exiting"
+        exit 1
+    fi
+
+    if [[ "$dir" != "" ]]; then
+        atlas_flags+=( --dir ${dir})
+
+    fi
+
     # Lint and Validate
     if [ "${step}" = "lint" ] || [ "${step}" = "all" ]; then
         echo +++ :database: lint and validate
 
         lint_result_file=$(mktemp)
         # Run the lint command with the web client, and output to json
-        atlas migrate lint --dev-url "${dev_url}" --dir "${dir}" -w --format "{{ json .  }}" --context "${atlas_context}" > "$lint_result_file" 2>&1
+
+
+        atlas migrate lint ${atlas_flags[@]} -w --format "{{ json .  }}" --context "${atlas_context}" > "$lint_result_file" 2>&1
+
+        lintResult=$?
+
+        if [[ $lintResult -ne 0 ]]; then
+            echo -e  ":scream_cat: error running atlas lint\n" | buildkite-agent annotate --context "atlas" --style "error"  --append
+            cat "$lint_result_file" | buildkite-agent annotate --context "atlas" --style "error"  --append
+
+            cat "$lint_result_file"
+            exit $lintResult
+        fi
 
         # Parse the results to display on the top of the buildkite job
         lint_result_file="$lint_result_file" parse_lint_result
@@ -73,11 +103,12 @@ function main() {
         fi
 
         # Run validate and exit early, if failed
-        atlas migrate validate --dev-url "${dev_url}" --dir "${dir}"
+        atlas migrate validate ${atlas_flags[@]}
         result=$?
         if [[ $result -ne 0 ]]; then
             exit "$result"
         fi
+
     fi
 
     # Push the migration if the step was enabled
@@ -85,7 +116,7 @@ function main() {
         echo +++ :rocket: push migrations
         # only push on the default branch
         if [ "${BUILDKITE_BRANCH}" = "${default_branch}" ]; then
-            atlas migrate push "${project}" --dev-url "${dev_url}" --dir "${dir}" --context "${atlas_context}"
+            atlas migrate push "${project}" ${atlas_flags[@]} --context "${atlas_context}"
             result=$?
         else
             echo not pushing migration, not running against "${default_branch}" branch
@@ -97,7 +128,7 @@ function main() {
     if [ "${step}" = "apply" ] || [ "${step}" = "all" ]; then
         echo +++ :shipit: apply migrations
         # only apply on the default branch
-        if [ "${BUILDKITE_BRANCH}" = "${default_branch}" ]; then
+        if [ "${BUILDKITE_BRANCH}" = "${default_branch}" ] && [ "$apply_env" != "" ] ; then
             atlas migrate apply --env "${apply_env}" --config "${atlas_config}"
             result=$?
         else

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,10 +15,13 @@ configuration:
     dev-url:
       type: string
       description: The URL of the dev-database to use for analysis
+    atlas-env:
+      type: string
+      description: The environment from atlas.hcl to use, not used if empty
     apply-env:
       type: string
-      description: The environment to apply the migration to, defaults to turso
-    atlas-config:
+      description: The environment to apply the migration to, not used if empty
+    config:
       type: string
       description: The path to the atlas hcl config file, defaults to `file://atlas.hcl`
     default-branch:
@@ -33,5 +36,4 @@ configuration:
   required:
     - dir
     - project
-    - dev-url
   additionalProperties: false

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -113,6 +113,7 @@ EOF
   export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
   export BUILDKITE_PLUGIN_ATLAS_STEP="all"
+  export BUILDKITE_PLUGIN_ATLAS_APPLY_ENV="neon"
   export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
   export CONTEXT=$(cat <<EOF
 {
@@ -126,7 +127,46 @@ EOF
     'migrate lint --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" --context "$CONTEXT" : echo lint' \
     'migrate validate --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
     'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --dev-url $BUILDKITE_PLUGIN_ATLAS_DEV_URL --dir $BUILDKITE_PLUGIN_ATLAS_DIR --context "$CONTEXT" : echo push' \
-    'migrate apply --env "turso" --config "file://atlas.hcl" : echo apply' \
+    'migrate apply --env "neon" --config "file://atlas.hcl" : echo apply' \
+
+
+  run "$PWD/hooks/command"
+
+  assert_success
+  assert_output --partial "+++ :database: lint"
+  assert_output --partial "lint"
+  assert_output --partial "validate"
+  assert_output --partial "+++ :rocket: push"
+  assert_output --partial "push"
+  assert_output --partial "apply"
+
+  unstub atlas
+}
+
+@test "do it all on main, with env" {
+  export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
+  export BUILDKITE_BRANCH="main"
+  export BUILDKITE_PLUGIN_ATLAS_ATLAS_ENV="dev"
+  export BUILDKITE_PLUGIN_ATLAS_DEV_URL="sqlite://dev?mode=memory&_fk=1"
+  export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
+  export BUILDKITE_PLUGIN_ATLAS_CONFIG="file://db/atlas.hcl"
+  export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+  export BUILDKITE_PLUGIN_ATLAS_STEP="all"
+  export BUILDKITE_PLUGIN_ATLAS_APPLY_ENV="neon"
+  export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+  export CONTEXT=$(cat <<EOF
+{
+    "branch": "main",
+    "commit": "24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
+}
+EOF
+)
+
+  stub atlas \
+    'migrate lint --env $BUILDKITE_PLUGIN_ATLAS_ATLAS_ENV --config $BUILDKITE_PLUGIN_ATLAS_CONFIG --dir $BUILDKITE_PLUGIN_ATLAS_DIR -w --format "{{ json .  }}" --context "$CONTEXT" : echo lint' \
+    'migrate validate --env $BUILDKITE_PLUGIN_ATLAS_ATLAS_ENV --config $BUILDKITE_PLUGIN_ATLAS_CONFIG --dir $BUILDKITE_PLUGIN_ATLAS_DIR : echo validate' \
+    'migrate push $BUILDKITE_PLUGIN_ATLAS_PROJECT --env $BUILDKITE_PLUGIN_ATLAS_ATLAS_ENV --config $BUILDKITE_PLUGIN_ATLAS_CONFIG --dir $BUILDKITE_PLUGIN_ATLAS_DIR --context "$CONTEXT" : echo push' \
+    'migrate apply --env "neon" --config $BUILDKITE_PLUGIN_ATLAS_CONFIG : echo apply' \
 
 
   run "$PWD/hooks/command"
@@ -149,7 +189,7 @@ EOF
   export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
   export BUILDKITE_PLUGIN_ATLAS_STEP="all"
-  export BUILDKITE_PLUGIN_APPLY_ENV="meow"
+  export BUILDKITE_PLUGIN_ATLAS_APPLY_ENV="meow"
   export BUILDKITE_PLUGIN_ATLAS_CONFIG="file://theopenlane-atlas.hcl"
   export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
   export CONTEXT=$(cat <<EOF
@@ -237,17 +277,16 @@ EOF
   assert_output --partial " BUILDKITE_PLUGIN_ATLAS_DIR: unbound variable"
 }
 
-@test "missing url" {
+
+@test "missing url and env" {
   export BUILDKITE_PIPELINE_DEFAULT_BRANCH="main"
   export BUILDKITE_BRANCH="meow"
   export BUILDKITE_PLUGIN_ATLAS_DIR="file://db/migrations"
   export BUILDKITE_PLUGIN_ATLAS_PROJECT="meow"
+  export BUILDKITE_COMMIT="24160da9f34e863b2d8fcc1fe6599d868e19f6b7"
 
   run "$PWD/hooks/command"
 
   assert_failure
-  assert_output --partial " BUILDKITE_PLUGIN_ATLAS_DEV_URL: unbound variable"
+  assert_output --partial "No atlas env or dev-url set, exiting"
 }
-
-
-


### PR DESCRIPTION
- fixes bugs with env vars
- allows for `atlas-env` or `dev-url` to be used
- removes default `turso` apply env
- error checks lint result before going to check result file

This is needed to be able to add postgres extensions to the dev env, e.g.:

https://github.com/theopenlane/core/pull/429/files#diff-c6525588b2bc57329d845c56f735516718b9f1c7cb2e02d00d917104893308fa