### PR TITLE
remove short circuit on linter result failure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
 
   - label: ":rocket: Test"
     plugins:
-      docker-compose#v5.6.0:
+      docker-compose#v5.10.0:
         run: tests
         cli-version: 2
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following to your `pipeline.yml`:
 ```yml
 steps:
   - plugins:
-      - theopenlane/atlas#v1.1.0:
+      - theopenlane/atlas#v1.2.0:
           dir: file://db/migrations
           project: theopenlane
           dev-url: sqlite://dev?mode=memory

--- a/hooks/command
+++ b/hooks/command
@@ -58,16 +58,6 @@ function main() {
 
         atlas migrate lint "${atlas_flags[@]}" -w --format "{{ json .  }}" --context "${atlas_context}" > "$lint_result_file" 2>&1
 
-        lintResult=$?
-
-        if [[ $lintResult -ne 0 ]]; then
-            echo -e  ":scream_cat: error running atlas lint\n" | buildkite-agent annotate --context "atlas" --style "error"  --append
-            buildkite-agent annotate --context "atlas" --style "error" --append < "$lint_result_file"
-
-            cat "$lint_result_file"
-            exit $lintResult
-        fi
-
         # Parse the results to display on the top of the buildkite job
         lint_result_file="$lint_result_file" parse_lint_result
 


### PR DESCRIPTION
This used to always have a `0` exit code if there were linter errors; this must have changed and we were never parsing the results. Skip the short circuit on error. 